### PR TITLE
Deprecated scrapy.spider namespace in serializer

### DIFF
--- a/scrapy_jsonrpc/serialize.py
+++ b/scrapy_jsonrpc/serialize.py
@@ -5,7 +5,7 @@ import decimal
 
 from twisted.internet import defer
 
-from scrapy.spider import Spider
+from scrapy.spiders import Spider
 from scrapy.http import Request, Response
 from scrapy.item import BaseItem
 


### PR DESCRIPTION
just annoying inside logs, not a big issue